### PR TITLE
javopen.co

### DIFF
--- a/submit_here/hosts.txt
+++ b/submit_here/hosts.txt
@@ -1,3 +1,4 @@
+javopen.co
 0.xxx-cdn.com
 zoo.cab
 equine.gq


### PR DESCRIPTION
I believe this domain is an Adult(-related) domain --> that have to 
be blocked as..

```python
javopen.co
```

## Comments

## Screenshots

<details><Summary>Screenshot required</summary>

![javopen1](https://user-images.githubusercontent.com/20802412/89736956-ccb06e00-da43-11ea-9c82-8aee09173739.png)
![javopen2](https://user-images.githubusercontent.com/20802412/89737099-eb633480-da44-11ea-810f-e142131c1c60.png)
![javopen3](https://user-images.githubusercontent.com/20802412/89737102-ee5e2500-da44-11ea-8593-413680039b40.png)

</details>

## External Info
<!-- if you have found your submission elsewhere, Please credit it by pasting a link here --->



### All Submissions:
- [x] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open
	[Merge Requests (MR)](../merge_requests) or [Issues](../issues) for
	the same update/change?
- [x] Added ScreenDump for prove of False Positive

### Todo
- [ ] Added to [Source file](submit_here/hosts.txt)?
