### PR TITLE
Add 2 other hosts

### DIFF
--- a/submit_here/hosts.txt
+++ b/submit_here/hosts.txt
@@ -777,6 +777,7 @@ backdoor.thumblogger.com
 backroomfuckers.com
 backseatbangers.com
 badbitchgifs.tumblr.com
+badhoe.com
 badoinkvr.com
 badpuppy.com
 badteenspunished.com
@@ -801,6 +802,7 @@ bangbros18.com
 bangbros.com
 bangbrosteenporn.com
 bangbus.com
+bangher.net
 bangteenpussy.com
 bangtubevideos.com
 banman.iafd.com


### PR DESCRIPTION
add badhoe,com and associated bangher.net

I believe this domain is an Adult(-related) domain --> that have to be blocked as..

```python
example.net
www.example.net
```

## Comments

## Screenshots

<details><Summary>Screenshot required</summary>



</details>

## External Info
<!-- if you have found your submission elsewhere, Please credit it by pasting a link here --->



### All Submissions:
- [ ] Have you followed the guidelines in our [Contributing](CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open
	[Merge Requests (MR)](../merge_requests) or [Issues](../issues) for
	the same update/change?
- [ ] Added ScreenDump for prove of False Positive

### Todo
- [ ] Added to [Source file](submit_here/hosts.txt)?
